### PR TITLE
Update Map Pins

### DIFF
--- a/Map Pins
+++ b/Map Pins
@@ -28,7 +28,6 @@ on('ready', function() {
         // Ensure image Markdown format is properly converted to HTML
         content = content.replace(/!\[([^\]]*)\]\((https?:\/\/[^\)]+)\)/g, '<img src="$2" alt="$1" style="max-width: 100%;" />');
 
-        // Remove button parsing (buttons and links are not needed)
         return content;
     }
 


### PR DESCRIPTION
!deleteMapPin: Deletes a selected Map Pin token and its corresponding mirror token.
!showMapPin: Displays the details of the Map Pin associated with the selected mirror token and updates the Map Pin handout with that information.
To add an image use: ![description](imageURL)